### PR TITLE
Fix mariadb installation (fix #4).

### DIFF
--- a/cmd/config.sh
+++ b/cmd/config.sh
@@ -10,4 +10,6 @@ cmd_config() {
     ds inject ubuntu-fixes.sh
     ds inject set_prompt.sh
     ds inject ssmtp.sh
+
+    ds inject mariadb.sh
 }

--- a/scripts/mariadb.sh
+++ b/scripts/mariadb.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -x
+
+# fix permissions
+chown -R mysql:mysql /var/lib/mysql
+chown -R mysql:mysql /var/log/mysql
+chown -R mysql:mysql /var/run/mysqld
+
+# create system tables, if they don't exist already
+[[ -d /var/lib/mysql/mysql ]] || mysql_install_db


### PR DESCRIPTION
When a new container is created, mariadb directories are mounted
from the host, and this breaks its installation:
https://github.com/docker-scripts/mariadb/blob/master/cmd/create.sh#L14-L16